### PR TITLE
Add GH Actions workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,30 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: Ruby
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+        with:
+          ruby-version: ' 3.0.6'
+      - name: Run tests
+        run: rake test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,6 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
         with:
-          ruby-version: ' 3.0.6'
+          ruby-version: '3.0.5'
       - name: Run tests
         run: rake test

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,5 @@
+require 'rake/testtask'
+
+Rake::TestTask.new do |task|
+  task.pattern = 'test/**/*_test.rb'
+end


### PR DESCRIPTION
This PR:
- Adds a rake task for running all tests.
- Adds the initial GH Actions workflows directory and file. The only check for now is `rake test`.